### PR TITLE
Make embedded google drive links to open in iframe

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -545,7 +545,7 @@ block script
           return true;
         } else if(link_url.match(/^.*.github.com\//)) {
           return true;
-        } else if(link_url.match(/^.*.drive.google.com\//)) {
+        } else if(link_url.match(/^.*drive.google.com\/(?!.*\/preview$)/)) {
           return true;
         } else if(link_url.match(/^.*.facebook.com\//)) {
           return true;


### PR DESCRIPTION
Although Google drive URLs in general cannot be opened in iframe, "embeded links" can.

Links that cannot be opened in iframes: `https://drive.google.com/file/d/0BxoI_EZ5krOaOG45bmNQQmJxMXM/view?usp=drive_web`

Links that _can_ be opened in iframes: `https://drive.google.com/file/d/0BxoI_EZ5krOaOG45bmNQQmJxMXM/preview`

Steps to retrieve links for embedding:
![embed](https://cloud.githubusercontent.com/assets/108608/11737476/8cdefdaa-a014-11e5-8784-018445928fd7.gif)
