### PR TITLE
Align tabletop column processing with hackfoldr 1.0.

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -614,13 +614,16 @@ block script
         Tabletop.init({
           key: csv_api_source_id,
           callback: function(data, tabletop){
+            var columnNames = tabletop.models[tabletop.model_names[0]].column_names
             data = data.map(function (o) {
-              result = [];
-              result[0] = o.url || "";
-              result[1] = o.title || "";
-              result[2] = o.foldrexpand || "";
-              result[3] = o["編輯註解"] || "";
-              result[4] = o.hints || "";
+              var result = ['', '', '', '', '']
+
+              columnNames.forEach(function(columnName, idx){
+                if(o[columnName]) {
+                  result[idx] = o[columnName];
+                }
+              });
+
               return result;
             });
             compile_json(data);


### PR DESCRIPTION
原本舊版 hackfoldr 的第一列的字亂打也沒關係，但 hackfoldr 2.0 裡面，第一列一定要取名為「url」「title」「foldrexpand」   「編輯註解」與「hints」。

這個 PR 把行為改回跟舊版 hackfoldr 一致。

**Breaking change**：如果有 hackfoldr 的欄位順序跟舊版不同、仰賴第一列的欄位名字的話，那麼 merge 這個 PR 之後，該 hackfoldr 就會壞掉。若原本 hackfoldr 2.0 是故意設計成要使用第一列的欄位名稱、讓使用者可以自訂欄位順序的話，請不要 merge 而直接 close 此 PR。
