### PR TITLE
Point /* to index.html in dev server

### DIFF
--- a/gulpfile.ls
+++ b/gulpfile.ls
@@ -32,6 +32,7 @@ gulp.task 'js', ->
 gulp.task 'server', ->
   app.use connect-livereload!
   app.use express.static path.resolve "#{build_path}"
+  app.get '/*', (req, res) -> res.sendFile path.resolve("#{build_path}/index.html")
   app.listen 3000
   gulp-util.log 'listening on port 3000'
 


### PR DESCRIPTION
So that visiting URLs like http://localhost:3000/g0v-hackath13n directly in browser during development does not get 404 Not Found.
